### PR TITLE
Allow ip_address to be specified in constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 dist/
 *.egg-info
 build/
+.idea/


### PR DESCRIPTION
I just noticed that I can use this API to talk to a Hero 4 GoPro when it is connected to a network while running in "WiFi RC" mode 🥇 

This works so long as your wifi adapter is running in AP mode, with a MAC address beginning with one of GoPro's vendor addresses, and a corresponding SSID that a GoPro Remote normally assigns itself (e.g. "D8:96:85:01:02:03" = "HERO-RC-010203"). Pairing can then be initiated by the camera once it notices a non-hidden SSID fitting that template name, with that mac vendor prefix.  Turns out the protocol you've implemented seems to be 100% accessible via such a connection once you've got dnsmasq + hostapd providing an IP layer for any number of connected gopros!

More detailed steps on getting that exact setup working here: https://goprohero.readthedocs.io/en/latest/Wifi%20Research/#gopro-remote-mode

Once you're connected to a gopro this way, in order to really benefit from that mode and communicate with potentially multiple cameras at once - we need to be able to specify and use GoPro's self.ip_addr in the constructor of your API, so that everywhere "10.5.5.9" used to be hard coded, we can now refer to a unique camera among potentially many.