### PR TITLE
Fix crash in GoPro.overview() when there is no SD

### DIFF
--- a/goprocam/GoProCamera.py
+++ b/goprocam/GoProCamera.py
@@ -860,6 +860,8 @@ class GoPro:
 		if param == "video_left":
 			return str(time.strftime("%H:%M:%S", time.gmtime(value)))
 		if param == "rem_space":
+			if value == 0:
+				return "No SD"
 			ammnt=1000
 			if self.whichCam() == "gpcontrol" and self.infoCamera("model_name") == "HERO4 Session":
 				ammnt=1


### PR DESCRIPTION
When there is no SD the camera returns "0" as space left and then
`overview` method try to calculate its logarithm.

Error reported:
```
	Traceback (most recent call last):
	  ...
	  File "/home/fark/workspace/catec/gopro-py-api/goprocam/GoProCamera.py", line 1080, in overview
	    print("space left in sd card: " + "" + self.parse_value("rem_space",self.getStatus(constants.Status.Status, constants.Status.STATUS.RemainingSpace)))
	  File "/home/fark/workspace/catec/gopro-py-api/goprocam/GoProCamera.py", line 870, in parse_value
	    i = int(math.floor(math.log(size_bytes, 1024)))
	ValueError: math domain error
```