### PR TITLE
Typo in git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install goprocam
 Git (unstable):
 
 ```bash
-git clone http://github.com/konradit/gopro_py_api
+git clone http://github.com/konradit/gopro-py-api
 cd gopro-py-api
 python setup.py install
 ```


### PR DESCRIPTION
I ran into an issue running the commands in the README.
$ git clone http://github.com/konradit/gopro_py_api
Cloning into 'gopro_py_api'...
remote: Repository not found.
fatal: repository 'https://github.com/konradit/gopro_py_api/' not found

This update fixes it up.
$ git clone http://github.com/konradit/gopro-py-api
Cloning into 'gopro-py-api'...
remote: Counting objects: 512, done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 512 (delta 18), reused 22 (delta 7), pack-reused 466
Receiving objects: 100% (512/512), 4.06 MiB | 3.49 MiB/s, done.
Resolving deltas: 100% (293/293), done.
Checking connectivity... done.