### PR TITLE
fixed HDR values shadowing

### DIFF
--- a/goprocam/constants.py
+++ b/goprocam/constants.py
@@ -453,7 +453,7 @@ class Photo:
 		M1= "6"
 		M1_5="7"
 		M2= "8"
-	HDR="100"
+	HDR_PHOTO="100"
 	class HDR:
 		OFF="0"
 		ON="1"


### PR DESCRIPTION
Renamed Photo.HDR constant as Photo.HDR_PHOTO (following Photo.WDR_PHOTO) to avoid shadowing by Photo.HDR class - issue #45.