### PR TITLE
Fixing indentation and syntax on 3 functions

### DIFF
--- a/goprocam/GoProCamera.py
+++ b/goprocam/GoProCamera.py
@@ -485,13 +485,13 @@ class GoPro:
 		self.gpControlCommand(r + "/protune/reset")
 	def setZoom(self, zoomLevel):
 		if zoomLevel >= 0 and zoomLevel <= 100:
-		self.gpControlCommand("digital_zoom?range_pcnt=" + zoomLevel)
+			self.gpControlCommand("digital_zoom?range_pcnt=" + zoomLevel)
 	##
 	## Query media list
 	##
 		def getMedia(self):
-		folder = ""
-		file_lo = ""
+			folder = ""
+			file_lo = ""
 		try:
 			raw_data = urllib.request.urlopen('http://' + self.ip_addr + ':8080/gp/gpMediaList').read().decode('utf-8')
 			json_parse = json.loads(raw_data)
@@ -846,7 +846,7 @@ class GoPro:
 				data=urllib.request.urlopen('http://' + self.ip_addr + ':8080/gp/gpMediaMetadata?p=' + folder + "/" + file + '&t=v4info').read().decode('utf-8')
 			jsondata=json.loads(data)
 			return jsondata[option] #"w":"4000","h":"3000" / "wdr":"0","raw":"0"
-	def getPhotoEXIF(self, option="", folder,="" file=""):
+	def getPhotoEXIF(self, option="", folder="", file=""):
 		if option == "":
 			if folder == "" and file == "":
 				if self.getMediaInfo("file").endswith("JPG"):


### PR DESCRIPTION
Addressing these issues:

~~~bash
from goprocam import GoProCamera
  File "/usr/local/lib/python3.7/site-packages/goprocam/GoProCamera.py", line 493
    folder = ""
         ^
IndentationError: expected an indented block
~~~

~~~bash
from goprocam import GoProCamera
  File "/usr/local/lib/python3.7/site-packages/goprocam/GoProCamera.py", line 849
    def getPhotoEXIF(self, option="", folder,="" file=""):
SyntaxError: invalid syntax
~~~

~~~bash
from goprocam import GoProCamera
  File "/usr/local/lib/python3.7/site-packages/goprocam/GoProCamera.py", line 488
    self.gpControlCommand("digital_zoom?range_pcnt=" + zoomLevel)
IndentationError: expected an indented block
~~~