### PR TITLE
Fix HERO3 file deletion

### DIFF
--- a/goprocam/GoProCamera.py
+++ b/goprocam/GoProCamera.py
@@ -341,16 +341,11 @@ class GoPro:
 	def deleteFile(self, folder,file):
 		"""Deletes a file. Pass folder and file as parameters."""
 		if folder.startswith("http://" + self.ip_addr):
-			self.getInfoFromURL(folder)
-			if self.whichCam() == "gpcontrol":
-				print(self.gpControlCommand("storage/delete?p=" + self.getInfoFromURL(folder)[0] + "/" + self.getInfoFromURL(folder)[1]))
-			else:
-				print(self.sendCamera("DF",self.getInfoFromURL(folder)[0]+"/"+self.getInfoFromURL(folder)[1]))
+			folder, file = self.getInfoFromURL(folder)
+		if self.whichCam() == "gpcontrol":
+			print(self.gpControlCommand("storage/delete?p=" + folder + "/" + file))
 		else:
-			if self.whichCam() == "gpcontrol":
-				print(self.gpControlCommand("storage/delete?p=" + folder + "/" + file))
-			else:
-				print(self.sendCamera("DF",folder+"/"+file))
+			print(self.sendCamera("DF","/"+folder+"/"+file))
 	def locate(self, param):
 		"""Starts or stops locating (beeps camera)"""
 		if self.whichCam() == "gpcontrol":


### PR DESCRIPTION
As a follow-up to 488db61, the folder needs to be prefixed with a slash, otherwise it doesn't delete anything. (Does the HERO4+ code work without the slash?) Reduced code duplication on the way.